### PR TITLE
Fix Codespaces to open entire repository

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,9 +2,9 @@
   "name": "Zep Eval Harness",
   "image": "mcr.microsoft.com/devcontainers/python:3.10",
 
-  "postCreateCommand": "pip install uv && bash ../.devcontainer/post-create.sh",
+  "postCreateCommand": "pip install uv && bash .devcontainer/post-create.sh",
 
-  "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}/zep-eval-harness",
+  "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
 
   "customizations": {
     "vscode": {
@@ -14,8 +14,9 @@
         "charliermarsh.ruff"
       ],
       "settings": {
-        "python.defaultInterpreterPath": ".venv/bin/python",
-        "python.terminal.activateEnvironment": true
+        "python.defaultInterpreterPath": "zep-eval-harness/.venv/bin/python",
+        "python.terminal.activateEnvironment": true,
+        "terminal.integrated.cwd": "${workspaceFolder}/zep-eval-harness"
       }
     }
   },

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,47 +1,62 @@
 #!/bin/bash
 set -e
 
-echo "=========================================="
-echo "  Setting up Zep Eval Harness Environment"
-echo "=========================================="
+echo ""
+echo "╔════════════════════════════════════════════════════════════════╗"
+echo "║                                                                ║"
+echo "║      Welcome to the Context Engineering Contest! 🎯           ║"
+echo "║                                                                ║"
+echo "╚════════════════════════════════════════════════════════════════╝"
+echo ""
+echo "Setting up your environment..."
 echo ""
 
-# We're already in the correct directory thanks to workspaceFolder setting
+# Navigate to zep-eval-harness directory
+cd zep-eval-harness
+
 # Install dependencies with uv
-echo "Installing dependencies with uv..."
+echo "📦 Installing dependencies with uv..."
 uv sync
 
-echo ""
-echo "Dependencies installed successfully!"
+echo "✅ Dependencies installed successfully!"
 echo ""
 
 # Check if .env exists, if not copy from .env.example
 if [ ! -f .env ]; then
-    # First try local .env.example, then check parent directory
     if [ -f .env.example ]; then
         cp .env.example .env
-        echo "Created .env from .env.example"
-    elif [ -f ../.env.example ]; then
-        cp ../.env.example .env
-        echo "Created .env from ../.env.example"
+        echo "✅ Created .env file from template"
     fi
 fi
 
 echo ""
-echo "=========================================="
-echo "  Setup Complete!"
-echo "=========================================="
+echo "╔════════════════════════════════════════════════════════════════╗"
+echo "║                    Setup Complete! ✨                          ║"
+echo "╚════════════════════════════════════════════════════════════════╝"
 echo ""
-echo "IMPORTANT: Before running the evaluation, you need to add your API keys."
+echo "What we've done for you:"
+echo "  ✅ Installed Python dependencies with uv"
+echo "  ✅ Created a .env file from template"
+echo "  ✅ Set up your development environment"
 echo ""
-echo "Edit the .env file and replace the placeholder values:"
-echo "  - ZEP_API_KEY=your_zep_api_key_here"
-echo "  - OPENAI_API_KEY=<provided-in-workshop>"
+echo "Next steps:"
 echo ""
-echo "Get your Zep API key from: https://app.getzep.com"
-echo "(The dataset is already pre-loaded in your Zep account)"
+echo "1. Add your API keys to the .env file:"
+echo "   📝 Edit: zep-eval-harness/.env"
 echo ""
-echo "Then run the evaluation:"
-echo "  uv run zep_evaluate.py"
+echo "   You'll need:"
+echo "   • ZEP_API_KEY - Get yours at https://app.getzep.com"
+echo "     (The marcus_chen_001 dataset is already pre-loaded!)"
+echo "   • OPENAI_API_KEY - Provided in the workshop"
 echo ""
-echo "=========================================="
+echo "2. Run your first evaluation:"
+echo "   🚀 uv run zep_evaluate.py"
+echo ""
+echo "3. Check the README for optimization strategies:"
+echo "   📖 cat README.md"
+echo ""
+echo "Your terminal is already in the zep-eval-harness directory."
+echo "You're ready to start optimizing! Good luck! 🎯"
+echo ""
+echo "════════════════════════════════════════════════════════════════"
+echo ""

--- a/README.md
+++ b/README.md
@@ -35,15 +35,23 @@ This contest challenges you to optimize context retrieval for a coding agent usi
 
 Make sure you open the Codespace on your fork (not the original repository) so you can push branches and create PRs.
 
+**What happens when you launch:**
+- The entire repository opens in VS Code
+- Dependencies are automatically installed with `uv sync`
+- A `.env` file is automatically created from the template
+- Your integrated terminal opens in the `zep-eval-harness` directory, ready to go
+
 ### 2. Set Up API Keys
 
-Your Codespace opens directly in the `zep-eval-harness` folder, so you're ready to go. Set up your environment:
+After your Codespace finishes setting up (watch for the welcome message), edit the automatically-created `.env` file with your API keys:
 
 ```bash
-cp .env.example .env
+# The .env file is in the zep-eval-harness directory
+# Your terminal is already there, so just edit it:
+code .env
 ```
 
-Edit the `.env` file with the following keys:
+Add these keys:
 
 **OpenAI API Key** (shared for this workshop):
 ```


### PR DESCRIPTION
## Summary

Fixes the Codespaces setup to open the entire repository instead of just the `zep-eval-harness` subfolder. The integrated terminal automatically opens in the correct working directory, and setup is streamlined with automatic `.env` file creation and a clear welcome message.

## Changes

- **Devcontainer**: Root workspace with terminal configured for `zep-eval-harness` directory
- **Setup script**: Enhanced welcome message showing progress and clear next steps  
- **README**: Updated to reflect automatic setup, removed manual file copy instructions

Users now see the full repository while having their terminal ready to run evaluation commands immediately.